### PR TITLE
Base filter for dust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.10
+
+ * Dust `base` filter
+
 ## 0.5.9
 
  * Fix create link https://github.com/getlackey/lackey-cms/issues/23

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Lackey](./docs/lackey-logo.png)
 
-_Version 0.5.8_
+_Version 0.5.10_
 
 Lackey is __Best Practice Driven CMS__
 

--- a/lib/server/init/views.js
+++ b/lib/server/init/views.js
@@ -30,7 +30,7 @@ let
     namingConvention = require('dust-naming-convention-filters');
 
 
-module.exports = (server) => {
+module.exports = (server, config) => {
 
     SCli.debug('lackey-cms/server/init/views', 'Setting up');
 
@@ -49,7 +49,7 @@ module.exports = (server) => {
 
     if (instance) {
         instance._dustHelpers.forEach((helper) => {
-            helper(dust.dust);
+            helper(dust.dust, config);
         });
     }
 

--- a/modules/cms/index.js
+++ b/modules/cms/index.js
@@ -35,6 +35,7 @@ const
     tweet = require('./server/lib/dust/tweet'),
     config = require('./server/lib/dust/config'),
     userHas = require('./server/lib/dust/user-has'),
+    base = require('./server/lib/dust/base'),
     socket = SUtils.cmsMod('core').path('server/models/media/sockets'),
     sitemap = require(LACKEY_PATH).sitemap;
 
@@ -58,6 +59,7 @@ module.exports = (instance) => {
     instance.addDustHelper(acronym);
     instance.addDustHelper(config);
     instance.addDustHelper(userHas);
+    instance.addDustHelper(base);
 
     sitemap.addSource(() => {
         return require('./server/controllers/content')

--- a/modules/cms/server/lib/dust/base.js
+++ b/modules/cms/server/lib/dust/base.js
@@ -1,0 +1,31 @@
+/* jslint node:true, esnext:true */
+'use strict';
+/*
+    Copyright 2016 Enigma Marketing Services Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+module.exports = (dust, config) => {
+  dust.filters.base = function (value) {
+
+    if (value && value.match(/^[a-zA-Z0-9]+\:\/\//)) {
+      return value;
+    }
+
+    let base = config.get('host').replace(/\/$/, ''),
+      val = value ? value.replace(/^\//, '') : '';
+
+    return base + '/' + val;
+  };
+};

--- a/modules/cms/test/server/lib/dust/base.test.js
+++ b/modules/cms/test/server/lib/dust/base.test.js
@@ -1,0 +1,103 @@
+/* jslint esnext:true, node:true, mocha:true */
+'use strict';
+/*
+    Copyright 2016 Enigma Marketing Services Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+const
+    base = require('../../../../server/lib/dust/base');
+
+require('should');
+
+describe('models/cms/server/lib/dust/base', () => {
+
+    it('http://google.com/ + /url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com/'
+            };
+        base(dust, config);
+        dust.filters.base('/url').should.be.eql('http://google.com/url');
+    });
+
+    it('http://google.com + /url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com'
+            };
+        base(dust, config);
+        dust.filters.base('/url').should.be.eql('http://google.com/url');
+    });
+
+    it('http://google.com + url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com'
+            };
+        base(dust, config);
+        dust.filters.base('url').should.be.eql('http://google.com/url');
+    });
+
+    it('http://google.com/url + /url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com/url'
+            };
+        base(dust, config);
+        dust.filters.base('/url').should.be.eql('http://google.com/url/url');
+    });
+
+    it('http://google.com/url/ + /url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com/url/'
+            };
+        base(dust, config);
+        dust.filters.base('/url').should.be.eql('http://google.com/url/url');
+    });
+
+    it('http://google.com/url + url', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com/url'
+            };
+        base(dust, config);
+        dust.filters.base('url').should.be.eql('http://google.com/url/url');
+    });
+
+    it('http://google.com/url + http://example.com', () => {
+        let dust = {
+                filters: {}
+            },
+            config = {
+                get: () => 'http://google.com/url'
+            };
+        base(dust, config);
+        dust.filters.base('http://example.com').should.be.eql('http://example.com');
+    });
+
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lackey-cms",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Lackey CMS",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Dust filter sorting out problems with routes

```dust
{someRoute|base}
```
Works as following
```
<HOST_IN_CONFIG> + <someRoute> = <base>
http://google.com/ + /url = http://google.com/url
http://google.com + /url = http://google.com/url
http://google.com + url = http://google.com/url
http://google.com/url + /url = http://google.com/url/url
http://google.com/url/ + /url = http://google.com/url/url
http://google.com/url + url = http://google.com/url/url
http://google.com/url + http://example.com = http://example.com
```